### PR TITLE
Derive home page expected sources from leaderboard configs

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,8 +1,8 @@
-# This stops the GitHub App from auto-summarizing and auto-reviewing
-pull_request_opened:
-  summary: false
-  code_review: false
-
-# This ensures the App still responds to your manual /gemini commands
+# Gemini Code Assist: https://developers.google.com/gemini-code-assist/docs/customize-gemini-behavior-github
 code_review:
+  # Still respond to manual /gemini commands on PRs
   disable: false
+  # No automatic summary or review when a PR is opened
+  pull_request_opened:
+    summary: false
+    code_review: false

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -16,27 +16,8 @@ export default function Home() {
   const [staleSources, setStaleSources] = useState<string[]>([]);
 
   const expectedSourcesByMode: Record<RankingMode, string[]> = {
-    general: [
-      'aa:omniscience',
-      'aa:hallucination',
-      'aa:gpqa',
-      'aa:ifbench',
-      'aa:longcontext',
-      'lmarena:text',
-      'lmarena:vision',
-      'lmarena:search',
-      'livebench:global',
-    ],
-    coding: [
-      'aa:livecodebench',
-      'aa:scicode',
-      'aa:terminalbench',
-      'aa:tau2',
-      'aa:longcontext',
-      'aa:ifbench',
-      'lmarena:webdev',
-      'swebench:bash',
-    ],
+    general: GENERAL_INTELLIGENCE.sources,
+    coding: CODING.sources,
   };
 
   const fetchRankings = useCallback(async (forceRefresh = false) => {


### PR DESCRIPTION
Uses GENERAL_INTELLIGENCE.sources and CODING.sources so the stale-source UI stays aligned with lib/rankings.ts.